### PR TITLE
Fix Scaffold to ScaffoldMessenger

### DIFF
--- a/#3 - Flutter Bloc Concepts/lib/main.dart
+++ b/#3 - Flutter Bloc Concepts/lib/main.dart
@@ -50,14 +50,14 @@ class _MyHomePageState extends State<MyHomePage> {
             BlocConsumer<CounterCubit, CounterState>(
               listener: (context, state) {
                 if (state.wasIncremented == true) {
-                  Scaffold.of(context).showSnackBar(
+                  ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text('Incremented!'),
                       duration: Duration(milliseconds: 300),
                     ),
                   );
                 } else if (state.wasIncremented == false) {
-                  Scaffold.of(context).showSnackBar(
+                  ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text('Decremented!'),
                       duration: Duration(milliseconds: 300),


### PR DESCRIPTION
New document shown `Scaffold.of(context).showSnackBar` has been replaced by `ScaffoldMessenger.of(context).showSnackBar`

Reference is https://docs.flutter.dev/release/breaking-changes/scaffold-messenger